### PR TITLE
change build arg image var names to match

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -2,7 +2,7 @@
 version: 1
 ansible_config: ansible.cfg
 build_arg_defaults:
-  ANSIBLE_RUNNER_IMAGE: 'quay.io/aap/ansible-automation-platform-20-ee-minimal-rhel8:latest'
-  PYTHON_BUILDER_IMAGE: 'quay.io/aap/ansible-automation-platform-20-ee-builder-rhel8:latest'
+  EE_BASE_IMAGE: 'quay.io/aap/ansible-automation-platform-20-ee-minimal-rhel8:latest'
+  EE_BUILDER_IMAGE: 'quay.io/aap/ansible-automation-platform-20-ee-builder-rhel8:latest'
 dependencies:
   galaxy: requirements.yml


### PR DESCRIPTION
the PR to change the build architecture of ansible-builder also change the variables that store the images in the execution env. this PR changes them in our demo to match what is needed as of the 1.0.0 release